### PR TITLE
Feat: Option allowing to specify which nested models to create + limit recursive model generation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,117 @@ export class TextLengthMore15 implements ValidatorConstraintInterface {
 }
 ```
 
+
+## Nested Forms and Models
+
+### Depth limiting
+
+By default, ngx-dynamic-form-builder will create all Submodels that it can find in specified model, with a max depth of 2.
+
+```ts
+class Company {
+	@Expose()
+	@Type(()=>User)
+	manager?:any;
+}
+
+class User {
+	@Expose()
+	name?: string;
+
+	@Type(type => Company)
+	@Expose()
+	company?: Company;
+}
+
+const form = new DynamicFormBuilder().rootFormGroup(User,{})
+
+/*
+  form.value will look like:
+  { 
+    name: '', 
+    company: { <-- sub model level 1
+      manager: { <-- sub model level 2
+        name: ''
+        --> no sub model level 3
+      }
+    }
+  }
+*/
+
+```
+
+You can change the depth by specifying a different value for maxNestedModelDepth:
+
+```ts
+const form = new DynamicFormBuilder().rootFormGroup(User,{}, {maxNestedModelDepth:0})
+
+/*
+  form.value will look like:
+  { 
+    name: '', 
+    --> no sub models at all
+  }
+*/
+```
+
+### Create only specific submodels
+
+Sometimes the form model may contain @Type decorated props, but you don't want these submodels to appear in the form.
+
+Use _allowedNestedModels_ to specify a list of props / dot-separated prop paths that you want to be created.
+
+All other submodels will be excluded.
+
+```ts
+
+/* Company + User from above example */
+
+class Package {
+	@Type(type => User)
+	@Expose()
+	user?: User;
+
+	@Type(type => Company)
+	@Expose()
+	company?: Company;
+}
+
+const form = new DynamicFormBuilder().rootFormGroup(Package,{}, {allowedNestedModels:[]})
+
+/*
+  form.value will look like:
+  { 
+    --> no sub models at all
+  }
+*/
+
+const form = new DynamicFormBuilder().rootFormGroup(Package,{}, {allowedNestedModels:['user','company']})
+
+/*
+  form.value will look like:
+  { 
+    user:{ name : '' },
+    company:{ },
+  }
+*/
+
+const form = new DynamicFormBuilder().rootFormGroup(Package,{}, {allowedNestedModels:['user','company','company.manager']})
+
+/*
+  form.value will look like:
+  { 
+    user: { name : '' },
+    company:{ 
+      manager: { name : '' }
+	},
+  }
+*/
+```
+
+
+
+
 ## Support multi-language translate validation errors (I18n)
 
 Because multi-language supported in class-validator-multi-lang, now ngx-dynamic-form-builder also support this feature

--- a/libs/ngx-dynamic-form-builder/src/lib/lib.ts
+++ b/libs/ngx-dynamic-form-builder/src/lib/lib.ts
@@ -44,6 +44,7 @@ import {
   IDynamicControlMetadata,
   ShortValidationErrors,
 } from './types/types';
+import { getGlobal } from './utils/get-global.util';
 import {
   getGlobalDynamicFormBuilderOptions,
   getGlobalDynamicFormBuilderOptionsSubject,
@@ -529,7 +530,7 @@ function getMetadata(
 ): IDynamicControlMetadata {
   const classTransformerMetadataStorage =
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)['classTransformerMetadataStorage'] || undefined;
+   getGlobal()['classTransformerMetadataStorage'] || undefined;
   if (!classTransformerMetadataStorage) {
     throw new Error(
       'classTransformerMetadataStorage not set in windows, please use the "class-transformer-global-storage" instead of "class-transformer"'
@@ -537,7 +538,8 @@ function getMetadata(
   }
   const classValidatorMetadataStorage =
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any)['classValidatorMetadataStorage'] || undefined;
+    getGlobal()['classValidatorMetadataStorage'] || undefined;
+    // (window as any)['classValidatorMetadataStorage'] || undefined;
   if (!classValidatorMetadataStorage) {
     throw new Error('classValidatorMetadataStorage not set in windows');
   }

--- a/libs/ngx-dynamic-form-builder/src/lib/types/types.ts
+++ b/libs/ngx-dynamic-form-builder/src/lib/types/types.ts
@@ -57,6 +57,7 @@ export interface DynamicFormBuilderOptions {
   classValidatorOptions?: ValidatorOptions;
   classTransformOptions?: ClassTransformOptions;
   classTransformToPlainOptions?: ClassTransformOptions;
+  maxNestedModelDepth?:number
 }
 
 export interface ClassValidatorErrors {

--- a/libs/ngx-dynamic-form-builder/src/lib/types/types.ts
+++ b/libs/ngx-dynamic-form-builder/src/lib/types/types.ts
@@ -57,7 +57,8 @@ export interface DynamicFormBuilderOptions {
   classValidatorOptions?: ValidatorOptions;
   classTransformOptions?: ClassTransformOptions;
   classTransformToPlainOptions?: ClassTransformOptions;
-  maxNestedModelDepth?:number
+  maxNestedModelDepth?:number;
+  allowedNestedModels?:string[];
 }
 
 export interface ClassValidatorErrors {

--- a/libs/ngx-dynamic-form-builder/src/lib/utils/get-global.util.ts
+++ b/libs/ngx-dynamic-form-builder/src/lib/utils/get-global.util.ts
@@ -4,7 +4,7 @@
  * Note: `globalThis` is the standardized approach however it has been added to
  * Node.js in version 12. We need to include this snippet until Node 12 EOL.
  */
-export function getGlobal() {
+export function getGlobal():any {
   if (typeof globalThis !== 'undefined') {
     return globalThis;
   }

--- a/libs/ngx-dynamic-form-builder/src/test/allowed-nested-models.spec.ts
+++ b/libs/ngx-dynamic-form-builder/src/test/allowed-nested-models.spec.ts
@@ -1,0 +1,176 @@
+import { Exclude, Expose, Type, Transform, classToClass, classToPlain, plainToClass, } from 'class-transformer-global-storage';
+import { DynamicFormBuilder, getGlobal } from '..';
+import { getMetadataStorage } from 'class-validator-multi-lang';
+  
+   import 'reflect-metadata';
+
+/**
+ * Note: jest uses cjs modules
+ */
+
+describe('allowed nested models', () => {
+
+	getMetadataStorage(); // required so that formbuilder will not abort because of missing validator
+
+	describe('empty data -- submodel', ()=>{
+		it('should not create any submodels if a empty list is specified', () => {
+			const defaultMetadataStorage = getGlobal()['classTransformerMetadataStorage'] || undefined;
+			defaultMetadataStorage.clear();
+	
+			class Company {
+				@Expose()
+				name?: string;
+				@Expose()
+				@Type(()=>User)
+				manager?:any;
+			}
+		
+			class User {
+				@Expose()
+				name?: string;
+		
+				@Type(type => Company, {})
+				@Expose()
+				optCompany?: Company = undefined;
+			}
+	
+			const fb = new DynamicFormBuilder();
+	
+			const form = fb.rootFormGroup(User,{}, {allowedNestedModels:[],maxNestedModelDepth:10})
+	
+			expect(form.value.optCompany).toBeUndefined();
+	
+		});
+		it('should create direct submodel', () => {
+			const defaultMetadataStorage = getGlobal()['classTransformerMetadataStorage'] || undefined;
+			defaultMetadataStorage.clear();
+	
+			class Company {
+				@Expose()
+				name?: string;
+				@Expose()
+				@Type(()=>User)
+				manager?:any;
+			}
+		
+			class User {
+				@Expose()
+				name?: string;
+		
+				@Type(type => Company, {})
+				@Expose()
+				optCompany?: Company = undefined;
+			}
+	
+			const fb = new DynamicFormBuilder();
+	
+			const form = fb.rootFormGroup(User,{}, {allowedNestedModels:['optCompany'],maxNestedModelDepth:10})
+	
+			expect(form.value.optCompany).toBeDefined();
+			expect(form.value.optCompany.manager).toBeUndefined();
+	
+		});
+		it('should create nested submodel', () => {
+			const defaultMetadataStorage = getGlobal()['classTransformerMetadataStorage'] || undefined;
+			defaultMetadataStorage.clear();
+	
+			class Company {
+				@Expose()
+				name?: string;
+				@Expose()
+				@Type(()=>User)
+				manager?:any;
+			}
+		
+			class User {
+				@Expose()
+				name?: string;
+		
+				@Type(type => Company, {})
+				@Expose()
+				optCompany?: Company = undefined;
+			}
+	
+			const fb = new DynamicFormBuilder();
+	
+			const form = fb.rootFormGroup(User,{}, {allowedNestedModels:['optCompany','optCompany.manager'],maxNestedModelDepth:10})
+	
+			expect(form.value.optCompany).toBeDefined();
+			expect(form.value.optCompany.manager).toBeDefined();
+			expect(form.value.optCompany.manager.optCompany).toBeUndefined();
+	
+		});
+	})
+
+	describe('empty data -- array submodel', ()=>{
+
+		it('should not create array submodel if not in list', () => {
+			const defaultMetadataStorage = getGlobal()['classTransformerMetadataStorage'] || undefined;
+			defaultMetadataStorage.clear();
+
+			class Company {
+				@Expose()
+				name?: string;
+				@Expose()
+				@Type(()=>User)
+				users?:any[];
+			}
+		
+			class User {
+				@Expose()
+				name?: string;
+		
+				@Type(type => Company, {})
+				@Expose()
+				optCompany?: Company = undefined;
+			}
+
+			const fb = new DynamicFormBuilder();
+
+			const form = fb.rootFormGroup(User,{}, {allowedNestedModels:['optCompany'],maxNestedModelDepth:10})
+
+			expect(form.value.optCompany).toBeDefined();
+			expect(form.value.optCompany.users).toBeUndefined();
+
+		});	
+
+		/*
+
+		Problem here: For unknown reasons, class-transformer is not able to determine the array type of Company.users.
+
+		it('should create array submodel if specified in list', () => {
+			const defaultMetadataStorage = getGlobal()['classTransformerMetadataStorage'] || undefined;
+			defaultMetadataStorage.clear();
+
+			class Company {
+				@Expose()
+				name?: string;
+				@Expose()
+				@Type(()=>User)
+				users:User[] = [];
+			}
+		
+			class User {
+				@Expose()
+				name?: string;
+		
+				@Type(type => Company, {})
+				@Expose()
+				optCompany?: Company = undefined;
+			}
+
+			const fb = new DynamicFormBuilder();
+
+			const form = fb.rootFormGroup(User,{}, {allowedNestedModels:['optCompany','optCompany.users'],maxNestedModelDepth:10})
+console.log(form.value.optCompany);
+			expect(form.value.optCompany).toBeDefined();
+			expect(form.value.optCompany.users).toBeDefined();
+			expect(Array.isArray(form.value.optCompany.users)).toBeTruthy();
+			expect(form.value.optCompany.users.length).toBe(0);
+
+		});	
+		*/
+
+	});
+
+});

--- a/libs/ngx-dynamic-form-builder/src/test/limit-depth.spec.ts
+++ b/libs/ngx-dynamic-form-builder/src/test/limit-depth.spec.ts
@@ -1,0 +1,106 @@
+import { Expose, Type } from 'class-transformer-global-storage';
+import { getMetadataStorage } from 'class-validator-multi-lang';
+import 'reflect-metadata';
+import { DynamicFormBuilder, getGlobal } from '..';
+  
+
+/**
+ * Note: jest uses cjs modules
+ */
+
+describe('limit depth', () => {
+
+	getMetadataStorage(); // required so that formbuilder will not abort because of missing validator
+
+	it('should respect depth of 2', () => {
+		const defaultMetadataStorage = getGlobal()['classTransformerMetadataStorage'] || undefined;
+		defaultMetadataStorage.clear();
+
+		class Company {
+			@Expose()
+			name?: string;
+			@Expose()
+			@Type(()=>User)
+			manager?:any;
+		}
+	
+		class User {
+			@Expose()
+			name?: string;
+	
+			@Type(type => Company, {})
+			@Expose()
+			optCompany?: Company = undefined;
+		}
+
+		const fb = new DynamicFormBuilder();
+
+		const form = fb.rootFormGroup(User,{},{maxNestedModelDepth:2})
+
+		expect(form.value.optCompany).toBeDefined();
+		expect(form.value.optCompany.manager).toBeDefined();
+		expect(form.value.optCompany.manager.optCompany).toBeUndefined();
+
+	});
+
+	it('should respect depth of 0', () => {
+		const defaultMetadataStorage = getGlobal()['classTransformerMetadataStorage'] || undefined;
+		defaultMetadataStorage.clear();
+
+		class Company {
+			@Expose()
+			name?: string;
+			@Expose()
+			@Type(()=>User)
+			manager?:any;
+		}
+	
+		class User {
+			@Expose()
+			name?: string;
+	
+			@Type(type => Company, {})
+			@Expose()
+			optCompany?: Company = undefined;
+		}
+
+		const fb = new DynamicFormBuilder();
+
+		const form = fb.rootFormGroup(User,{},{maxNestedModelDepth:0})
+
+		expect(form.value.optCompany).toBeUndefined();
+
+	});
+
+	it('should allow partial recursiveness', () => {
+		const defaultMetadataStorage = getGlobal()['classTransformerMetadataStorage'] || undefined;
+		defaultMetadataStorage.clear();
+
+		class Company {
+			@Expose()
+			name?: string;
+			@Expose()
+			@Type(()=>User)
+			manager?:any;
+		}
+	
+		class User {
+			@Expose()
+			name?: string;
+	
+			@Type(type => Company, {})
+			@Expose()
+			optCompany?: Company = undefined;
+		}
+
+		const fb = new DynamicFormBuilder();
+
+		const form = fb.rootFormGroup(User,{},{maxNestedModelDepth:5})
+
+		expect(form.value.optCompany.manager.optCompany).toBeDefined();
+		expect(form.value.optCompany.manager.optCompany.manager).toBeDefined();
+		expect(form.value.optCompany.manager.optCompany.manager.optCompany).toBeDefined();
+		expect(form.value.optCompany.manager.optCompany.manager.optCompany.manager).toBeUndefined();
+
+	});
+});

--- a/libs/ngx-dynamic-form-builder/tsconfig.spec.json
+++ b/libs/ngx-dynamic-form-builder/tsconfig.spec.json
@@ -2,8 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
-    "types": ["jest", "node"]
+    "module": "es2015",
+    "target": "es2015",
+    "types": ["jest", "node"],
+	"esModuleInterop": true
   },
   "files": ["src/test-setup.ts"],
   "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]


### PR DESCRIPTION
As discussed in https://github.com/EndyKaufman/ngx-dynamic-form-builder/issues/185
here is my proposal for implementation of controlling which and how many nested models should be created.

In order to implement the needed changes, I first had to do small tweaks before:

* lib was getting reference to class-transformer/validator storage from window. This does not work in jest/node env, so it was updated to use the getGlobal() function.
* tsconfig.spec.json has been updated to allow jest tests to run correctly. 
* I'm not fast with cypress, so I added jest tests based on the runner that nx already provides.

Regarding the implementation, I think the commits speak for themselves, refer to the tests and updated readme to see how it is working.
